### PR TITLE
Change: adjust topnav component height and add `z-index` on it.

### DIFF
--- a/src/components/base/NavItemsGroup/NavItemsGroup.tsx
+++ b/src/components/base/NavItemsGroup/NavItemsGroup.tsx
@@ -52,7 +52,7 @@ export const NavItemsGroup: FC<INavItemsGroup> = ({
 
   return (
     <ul
-      className={`flex font-serif text-2xl font-medium ${directionClass} ${spaceClass}`}
+      className={`flex font-serif text-xl lg:text-2xl font-medium ${directionClass} ${spaceClass}`}
     >
       {TOP_LEVEL_NAV.map((pathName, idx) => (
         <NavItem

--- a/src/components/blocks/CollaborationCta/CollaborationCta.tsx
+++ b/src/components/blocks/CollaborationCta/CollaborationCta.tsx
@@ -25,7 +25,7 @@ export const CollaborationCta: FC<ICollaborationCta> = () => {
     <Section hasVerticalPadding centerContent>
       <div className="bg-base-dim md:px-14 rounded-xl md:py-12 px-7 py-6">
         <h3 className="md:text-3xl font-serif text-2xl">
-          I&#39;m open to help and am available for freelance opportunities and
+          I&#39;m open to help and available for freelance opportunities and
           collaborations worldwide!
         </h3>
         <div className="md:flex-row md:space-x-6 md:space-y-0 flex flex-col mt-6 space-y-6">

--- a/src/components/blocks/MobileSideNav/MobileSideNav.tsx
+++ b/src/components/blocks/MobileSideNav/MobileSideNav.tsx
@@ -50,7 +50,7 @@ export const MobileSideNav: FC<IMobileSideNav> = () => {
       <nav className="bg-base-light absolute top-0 right-0 w-full h-screen max-w-xs px-6">
         {/* Toggle off side nav */}
         {/* The `min-h-[]` class name is measured by calculating top nav header's height. */}
-        <div className="flex items-center justify-end min-h-[5rem] md:min-h-[7.75rem]">
+        <div className="topnav-offset-h flex items-center justify-end">
           <button onClick={toggleSideNav} className="outline-none">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/components/blocks/Section/Section.tsx
+++ b/src/components/blocks/Section/Section.tsx
@@ -37,7 +37,7 @@ export const Section: FC<ISection> = ({
   const { className, ...rest } = props;
   const dynamicPropClass = clsx({
     "py-12": hasVerticalPadding,
-    "min-h-[calc(100vh-5rem)] md:min-h-[calc(100vh-7.75rem)]": isOnTop,
+    "topnav-offset-vh": isOnTop,
   });
   const mergedClassName = dynamicPropClass.concat(
     ...[className ? " " + className : ""]

--- a/src/components/blocks/TopNav/TopNav.tsx
+++ b/src/components/blocks/TopNav/TopNav.tsx
@@ -20,8 +20,8 @@ export interface ITopNav {}
  */
 export const TopNav: FC<ITopNav> = () => {
   return (
-    <header className="bg-base-light sticky top-0 shadow-sm">
-      <CenterContent py="m">
+    <header className="bg-base-light sticky top-0 z-40 shadow-sm">
+      <CenterContent py="s">
         <nav className="flex items-center justify-between">
           {/* LHS */}
           <Link href="/">

--- a/src/components/layout/PageBaseLayout/PageBaseLayout.tsx
+++ b/src/components/layout/PageBaseLayout/PageBaseLayout.tsx
@@ -29,7 +29,7 @@ export const PageBaseLayout: FC<IPageBaseLayout> = ({
       <TopNav />
       <MobileSideNav />
 
-      <main className="min-h-[calc(100vh-5rem)] md:min-h-[calc(100vh-7.75rem)]">
+      <main className="topnav-offset-vh">
         {children || <ComingSoonMessage />}
       </main>
 

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -16,3 +16,16 @@
     @apply outline-none focus:ring-2 focus:ring-primary-light rounded-sm;
   }
 }
+
+/**
+ * Whenever you change the height of top level navigation and header (or its content),
+ *  you need to recalculate this two classes manually.
+ *
+ * It's kinda pain, but it is what it is.
+ */
+.topnav-offset-h {
+  @apply min-h-[3.5rem] md:min-h-[4rem];
+}
+.topnav-offset-vh {
+  @apply min-h-[calc(100vh-3.5rem)] md:min-h-[calc(100vh-4rem)];
+}


### PR DESCRIPTION
- `NavItemsGroup`: adjust text size (smaller) for mobile device.
- `CollaborationCta`: fix wording i guess.
- `MobileSideNav`, `Section`, and `PageBaseLayout`: use global css class so it is now configurable easily.